### PR TITLE
Added Encoding.calcCharCountForTokens method

### DIFF
--- a/lib/src/main/java/com/knuddels/jtokkit/api/Encoding.java
+++ b/lib/src/main/java/com/knuddels/jtokkit/api/Encoding.java
@@ -165,4 +165,21 @@ public interface Encoding {
      * @return the name of this encoding
      */
     String getName();
+
+    /**
+     * Calculates the total number of characters that encompass a specified number of tokens in the given text.
+     * Counts the characters up to and including the last character of the tokenCount-th token.
+     * If the tokenCount is larger than the number of tokens in the text, the total character count of the text is returned.
+     * This method does not throw an exception if the text contains special tokens, but instead
+     * encodes them as if they were ordinary text.
+     * This method does not adjust for multi-token characters.
+     *
+     * @param text       The string in which tokens are to be counted.
+     * @param tokenCount The number of tokens for which the character count is calculated.
+     *                   This count includes spaces or delimiters if they are part of the tokens.
+     * @return           The total character count for the specified number of tokens in the text.
+     *                   Returns -1 if tokenCount is less than 1 or text is null.
+     */
+    int calcCharCountForTokens(String text, int tokenCount);
+
 }

--- a/lib/src/test/java/com/knuddels/jtokkit/BaseEncodingRegistryTest.java
+++ b/lib/src/test/java/com/knuddels/jtokkit/BaseEncodingRegistryTest.java
@@ -181,5 +181,10 @@ abstract class BaseEncodingRegistryTest<T extends AbstractEncodingRegistry> {
         public String getName() {
             return "dummy";
         }
+
+        @Override
+        public int calcCharCountForTokens(String text , int tokenCount){
+            return 0;
+        }
     }
 }

--- a/lib/src/test/java/com/knuddels/jtokkit/Cl100kTest.java
+++ b/lib/src/test/java/com/knuddels/jtokkit/Cl100kTest.java
@@ -232,4 +232,25 @@ class Cl100kTest {
                 throw new IllegalStateException();
         }
     }
+
+    @Test
+    void testCalcCharCountForTokensWithRandomStrings() {
+        var singleTokenStrings = getAllTokens();
+        IntStream.range(0, 100_000).parallel().forEach(i -> {
+            String testString;
+            do {
+                testString = generateRandomString(10, singleTokenStrings);
+            } while (!UTF_8.newEncoder().canEncode(testString));
+
+            var maxTokenCount = rand().nextInt(1, 2 * testString.length());
+
+            int charCount = getEncoding().calcCharCountForTokens(testString, maxTokenCount);
+            var encoded = getEncoding().encodeOrdinary(testString, maxTokenCount);
+            if (!encoded.isTruncated()) {
+                var actualTokens = encoded.getTokens();
+                var decodedTokens = getEncoding().decode(actualTokens);
+                assertEquals(decodedTokens.length(), charCount);
+            }
+        });
+    }
 }


### PR DESCRIPTION
A very common use case for token counting is when chunking a long text to fit in a model context window. In order to efficiently use jtokkit library for this purpose, we need to be able to count number of characters for given token count. I added Encoding.calcCharCountForTokens method that does that. 
Please, review and accept the pull request if it makes sense. 