### PR TITLE
Add Encoding.calcCharCountForTokens method

### DIFF
--- a/lib/src/main/java/com/knuddels/jtokkit/Cl100kParser.java
+++ b/lib/src/main/java/com/knuddels/jtokkit/Cl100kParser.java
@@ -28,11 +28,12 @@ class Cl100kParser {
             .sorted()
             .toArray();
 
-    static void split(String input, Predicate<ByteArrayList> fragmentConsumer) {
+    static int split(String input, Predicate<ByteArrayList> fragmentConsumer) {
         assert isValidUTF8(input) : "Input is not UTF-8: " + input;
         ByteArrayList utf8Bytes = new ByteArrayList();
         boolean finished = false;
-        for (int endIndex = 0; endIndex < input.length() && !finished; ) {
+        int endIndex = 0;
+        while (endIndex < input.length() && !finished) {
             int startIndex = endIndex;
             int c0 = input.codePointAt(startIndex);
             int cc0 = charCount(c0);
@@ -123,6 +124,7 @@ class Cl100kParser {
                 }
             }
         }
+        return endIndex;
     }
 
 

--- a/lib/src/main/java/com/knuddels/jtokkit/EncodingFactory.java
+++ b/lib/src/main/java/com/knuddels/jtokkit/EncodingFactory.java
@@ -176,14 +176,15 @@ class EncodingFactory {
         }
 
         @Override
-        int encodeOrdinaryInternal(String text, int maxTokenCount, boolean keepEncodings, IntArrayList out) {
+        GptBytePairEncoding.InternalEncodingResult encodeOrdinaryInternal(String text, int maxTokenCount, boolean keepEncodings, IntArrayList out) {
             int[] tokenCount = {0};
             IntArrayList ranks = new IntArrayList();
-            Cl100kParser.split(text, utf8BytesList -> {
+            int endIndex = Cl100kParser.split(text, utf8BytesList -> {
                 tokenCount[0] += encoder.addTokensAndGetCount(maxTokenCount, keepEncodings, utf8BytesList.toArray(), out, ranks);
                 return tokenCount[0] >= maxTokenCount;
             });
-            return tokenCount[0];
+            return new InternalEncodingResult(tokenCount[0], endIndex);
+
         }
     }
 }

--- a/lib/src/main/java/com/knuddels/jtokkit/GptBytePairEncoding.java
+++ b/lib/src/main/java/com/knuddels/jtokkit/GptBytePairEncoding.java
@@ -91,14 +91,14 @@ class GptBytePairEncoding implements Encoding {
 
     InternalEncodingResult encodeOrdinaryInternal(String text, int maxTokenCount, boolean keepEncodings, IntArrayList out) {
         int tokenCount = 0;
-        int lastTokenPosition = 0;
+        int endCharIndex = 0;
         IntArrayList ranks = new IntArrayList(); // reused to avoid allocations
         for (Matcher matcher = pattern.matcher(text); tokenCount < maxTokenCount && matcher.find(); ) {
             byte[] bytes = matcher.group().getBytes(UTF_8);
             tokenCount += encoder.addTokensAndGetCount(maxTokenCount, keepEncodings, bytes, out, ranks);
-            lastTokenPosition = matcher.end();
+            endCharIndex = matcher.end();
         }
-        return new InternalEncodingResult(tokenCount, lastTokenPosition);
+        return new InternalEncodingResult(tokenCount, endCharIndex);
     }
 
     @Override
@@ -110,7 +110,7 @@ class GptBytePairEncoding implements Encoding {
     public int calcCharCountForTokens(String text , int tokenCount) {
         IntArrayList out = new IntArrayList();
         InternalEncodingResult result = encodeOrdinaryInternal(text, tokenCount, false, out);
-        return result.getLastTokenPosition();
+        return result.getEndCharIndex();
     }
 
     @Override
@@ -175,21 +175,21 @@ class GptBytePairEncoding implements Encoding {
         }
     }
 
-    private static final class InternalEncodingResult {
+    protected static final class InternalEncodingResult {
         private final int tokenCount;
-        private final int lastTokenPosition;
+        private final int endCharIndex;
 
         public int getTokenCount() {
             return tokenCount;
         }
 
-        public int getLastTokenPosition() {
-            return lastTokenPosition;
+        public int getEndCharIndex() {
+            return endCharIndex;
         }
 
-        public InternalEncodingResult(int tokenCount, int lastTokenPosition) {
+        public InternalEncodingResult(int tokenCount, int endCharIndex) {
             this.tokenCount = tokenCount;
-            this.lastTokenPosition = lastTokenPosition;
+            this.endCharIndex = endCharIndex;
         }
 
     }

--- a/lib/src/main/java/com/knuddels/jtokkit/api/Encoding.java
+++ b/lib/src/main/java/com/knuddels/jtokkit/api/Encoding.java
@@ -201,4 +201,21 @@ public interface Encoding {
      * @return the name of this encoding
      */
     String getName();
+
+    /**
+     * Calculates the total number of characters that encompass a specified number of tokens in the given text.
+     * Counts the characters up to and including the last character of the tokenCount-th token.
+     * If the tokenCount is larger than the number of tokens in the text, the total character count of the text is returned.
+     * This method does not throw an exception if the text contains special tokens, but instead
+     * encodes them as if they were ordinary text.
+     * This method does not adjust for multi-token characters.
+     *
+     * @param text       The string in which tokens are to be counted.
+     * @param tokenCount The number of tokens for which the character count is calculated.
+     *                   This count includes spaces or delimiters if they are part of the tokens.
+     * @return           The total character count for the specified number of tokens in the text.
+     *                   Returns -1 if tokenCount is less than 1 or text is null.
+     */
+    int calcCharCountForTokens(String text, int tokenCount);
+
 }

--- a/lib/src/test/java/com/knuddels/jtokkit/BaseEncodingRegistryTest.java
+++ b/lib/src/test/java/com/knuddels/jtokkit/BaseEncodingRegistryTest.java
@@ -193,5 +193,10 @@ abstract class BaseEncodingRegistryTest<T extends AbstractEncodingRegistry> {
         public String getName() {
             return "dummy";
         }
+
+        @Override
+        public int calcCharCountForTokens(String text , int tokenCount){
+            return 0;
+        }
     }
 }

--- a/lib/src/test/java/com/knuddels/jtokkit/Cl100kTest.java
+++ b/lib/src/test/java/com/knuddels/jtokkit/Cl100kTest.java
@@ -269,7 +269,7 @@ class Cl100kTest {
         IntStream.range(0, 100_000).parallel().forEach(i -> {
             String testString;
             do {
-                testString = generateRandomString(10, singleTokenStrings);
+                testString = generateRandomUtf8String( singleTokenStrings);
             } while (!UTF_8.newEncoder().canEncode(testString));
 
             var maxTokenCount = rand().nextInt(1, 2 * testString.length());

--- a/lib/src/test/java/com/knuddels/jtokkit/Cl100kTest.java
+++ b/lib/src/test/java/com/knuddels/jtokkit/Cl100kTest.java
@@ -262,4 +262,25 @@ class Cl100kTest {
                 throw new IllegalStateException();
         }
     }
+
+    @Test
+    void testCalcCharCountForTokensWithRandomStrings() {
+        var singleTokenStrings = getAllTokens();
+        IntStream.range(0, 100_000).parallel().forEach(i -> {
+            String testString;
+            do {
+                testString = generateRandomString(10, singleTokenStrings);
+            } while (!UTF_8.newEncoder().canEncode(testString));
+
+            var maxTokenCount = rand().nextInt(1, 2 * testString.length());
+
+            int charCount = getEncoding().calcCharCountForTokens(testString, maxTokenCount);
+            var encoded = getEncoding().encodeOrdinary(testString, maxTokenCount);
+            if (!encoded.isTruncated()) {
+                var actualTokens = encoded.getTokens();
+                var decodedTokens = getEncoding().decode(actualTokens);
+                assertEquals(decodedTokens.length(), charCount);
+            }
+        });
+    }
 }


### PR DESCRIPTION
A very common use case for token counting is when chunking a long text to fit in a model context window. In order to efficiently use jtokkit library for this purpose, we need to be able to count number of characters for given token count. I added Encoding.calcCharCountForTokens method that does that.
Please, review and accept the pull request if it makes sense.
I updated the implementation for the latest code.