### PR TITLE
add gpt-4o-mini model

### DIFF
--- a/lib/src/main/java/com/knuddels/jtokkit/api/ModelType.java
+++ b/lib/src/main/java/com/knuddels/jtokkit/api/ModelType.java
@@ -10,6 +10,7 @@ public enum ModelType {
     // chat
     GPT_4("gpt-4", EncodingType.CL100K_BASE, 8192),
     GPT_4O("gpt-4o", EncodingType.O200K_BASE, 128000),
+    GPT_4O_MINI("gpt-4o-mini", EncodingType.O200K_BASE, 128000),
     GPT_4_32K("gpt-4-32k", EncodingType.CL100K_BASE, 32768),
     GPT_4_TURBO("gpt-4-turbo", EncodingType.CL100K_BASE, 128000),
     GPT_3_5_TURBO("gpt-3.5-turbo", EncodingType.CL100K_BASE, 16385),


### PR DESCRIPTION
OpenAI has added gpt-4o-mini model to API. See https://platform.openai.com/docs/models/gpt-4o-mini