### PR TITLE
Optimise getEncodingForModel

### DIFF
--- a/lib/src/main/java/com/knuddels/jtokkit/AbstractEncodingRegistry.java
+++ b/lib/src/main/java/com/knuddels/jtokkit/AbstractEncodingRegistry.java
@@ -36,16 +36,8 @@ abstract class AbstractEncodingRegistry implements EncodingRegistry {
             return Optional.of(getEncodingForModel(ModelType.GPT_4O));
         }
 
-        if (modelName.startsWith(ModelType.GPT_4_32K.getName())) {
-            return Optional.of(getEncodingForModel(ModelType.GPT_4_32K));
-        }
-
         if (modelName.startsWith(ModelType.GPT_4.getName())) {
             return Optional.of(getEncodingForModel(ModelType.GPT_4));
-        }
-
-        if (modelName.startsWith(ModelType.GPT_3_5_TURBO_16K.getName())) {
-            return Optional.of(getEncodingForModel(ModelType.GPT_3_5_TURBO_16K));
         }
 
         if (modelName.startsWith(ModelType.GPT_3_5_TURBO.getName())) {


### PR DESCRIPTION
The same results are returned with less modelName.startsWith calls