### PR TITLE
GPT O1-preview and O1-mini

### DIFF
--- a/lib/src/main/java/com/knuddels/jtokkit/api/ModelType.java
+++ b/lib/src/main/java/com/knuddels/jtokkit/api/ModelType.java
@@ -8,6 +8,8 @@ import java.util.stream.Collectors;
 
 public enum ModelType {
     // chat
+    GPT_O1_PREVIEW("gpt-4o", EncodingType.O200K_BASE, 128000),
+    GPT_O1_MINI("gpt-4o", EncodingType.O200K_BASE, 128000),
     GPT_4("gpt-4", EncodingType.CL100K_BASE, 8192),
     GPT_4O("gpt-4o", EncodingType.O200K_BASE, 128000),
     GPT_4O_MINI("gpt-4o-mini", EncodingType.O200K_BASE, 128000),


### PR DESCRIPTION
Added OpenAI GPT O1-preview and OpenAI GPT O1-mini models to the ModelType enum. These Models were released to the Tier 5 Users on 12th September 2024.

Sources:
https://openai.com/index/introducing-openai-o1-preview/
https://openai.com/index/openai-o1-mini-advancing-cost-efficient-reasoning/