### PR TITLE
Fix edit urls in docs

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -33,7 +33,7 @@ const config = {
 			({
 				docs: {
 					sidebarPath: require.resolve('./sidebars.js'),
-					editUrl: 'https://github.com/knuddelsgmbh/jtokkit/docs',
+					editUrl: 'https://github.com/knuddelsgmbh/jtokkit/tree/main/docs',
 				},
 				theme: {
 					customCss: require.resolve('./src/css/custom.css'),


### PR DESCRIPTION
Currently when you click on the "Edit this page" links in the docs it goes to a "Not Found" page on github.