### PR TITLE
feat: add o200k_harmony encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ the need to have similar capacities in the JVM ecosystem as the library
 ## 🤖 Features
 
 ✅ Implements encoding and decoding via `r50k_base`, `p50k_base`, `p50k_edit`,
-`cl100k_base` and `o200k_base`
+`cl100k_base`, `o200k_base` and `o200k_harmony`
 
 ✅ Easy-to-use API
 

--- a/docs/docs/getting-started/intro.md
+++ b/docs/docs/getting-started/intro.md
@@ -8,7 +8,8 @@ JTokkit is a fast and efficient tokenizer designed for use in natural language p
 
 ## Features
 
-✅ Implements encoding and decoding via `r50k_base`, `p50k_base`, `p50k_edit` and `cl100k_base`
+✅ Implements encoding and decoding via `r50k_base`, `p50k_base`, `p50k_edit`, 
+`cl100k_base`, `o200k_base` and `o200k_harmony`
 
 ✅ Easy-to-use API
 

--- a/lib/src/main/java/com/knuddels/jtokkit/AbstractEncodingRegistry.java
+++ b/lib/src/main/java/com/knuddels/jtokkit/AbstractEncodingRegistry.java
@@ -96,6 +96,9 @@ abstract class AbstractEncodingRegistry implements EncodingRegistry {
             case O200K_BASE:
                 encodings.computeIfAbsent(encodingType.getName(), k -> EncodingFactory.o200kBase());
                 break;
+            case O200K_HARMONY:
+                encodings.computeIfAbsent(encodingType.getName(), k -> EncodingFactory.o200kHarmony());
+                break;
             default:
                 throw new IllegalStateException("Unknown encoding type " + encodingType.getName());
         }

--- a/lib/src/main/java/com/knuddels/jtokkit/api/EncodingType.java
+++ b/lib/src/main/java/com/knuddels/jtokkit/api/EncodingType.java
@@ -11,7 +11,8 @@ public enum EncodingType {
     P50K_BASE("p50k_base"),
     P50K_EDIT("p50k_edit"),
     CL100K_BASE("cl100k_base"),
-    O200K_BASE("o200k_base");
+    O200K_BASE("o200k_base"),
+    O200K_HARMONY("o200k_harmony");
 
     private static final Map<String, EncodingType> nameToEncodingType = Arrays.stream(values())
             .collect(Collectors.toMap(EncodingType::getName, Function.identity()));

--- a/lib/src/test/java/com/knuddels/jtokkit/reference/O200kHarmonyTest.java
+++ b/lib/src/test/java/com/knuddels/jtokkit/reference/O200kHarmonyTest.java
@@ -1,0 +1,110 @@
+package com.knuddels.jtokkit.reference;
+
+import com.knuddels.jtokkit.Encodings;
+import com.knuddels.jtokkit.api.Encoding;
+import com.knuddels.jtokkit.api.EncodingType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvFileSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class O200kHarmonyTest {
+
+    private static final Encoding ENCODING = Encodings.newDefaultEncodingRegistry().getEncoding(EncodingType.O200K_HARMONY);
+
+    @ParameterizedTest
+    @CsvFileSource(resources = "/o200k_base_encodings.csv", numLinesToSkip = 1, maxCharsPerColumn = 1_000_000)
+    void o200kBaseEncodesCorrectly(
+            String input,
+            String output
+    ) {
+        var expected = TestUtils.parseEncodingString(output);
+        var actual = ENCODING.encode(input);
+
+        assertEquals(expected, actual);
+    }
+
+    @ParameterizedTest
+    @CsvFileSource(resources = "/o200k_base_encodings.csv", numLinesToSkip = 1, maxCharsPerColumn = 1_000_000)
+    void o200kHarmonyEncodesStable(String input) {
+        var actual = ENCODING.decode(ENCODING.encode(input));
+
+        assertEquals(input, actual);
+    }
+
+    @ParameterizedTest
+    @CsvFileSource(resources = "/o200k_base_encodings.csv", numLinesToSkip = 1, maxCharsPerColumn = 1_000_000)
+    void o200kHarmonyEncodesCorrectlyWithMaxTokensSet(
+            String input,
+            String output,
+            String outputMaxTokens10
+    ) {
+        var expected = TestUtils.parseEncodingString(output);
+        var expectedWithMaxTokens = TestUtils.parseEncodingString(outputMaxTokens10);
+        var encodingResult = ENCODING.encode(input, 10);
+
+        assertEquals(expectedWithMaxTokens, encodingResult.getTokens());
+        assertEquals(expected.size() > expectedWithMaxTokens.size(), encodingResult.isTruncated());
+    }
+
+    @ParameterizedTest
+    @CsvFileSource(resources = "/o200k_base_encodings.csv", numLinesToSkip = 1, maxCharsPerColumn = 1_000_000)
+    void o200kHarmonyEncodesStableWithMaxTokensSet(String input) {
+        var actual = ENCODING.decode(ENCODING.encode(input, 10).getTokens());
+
+        assertTrue(input.startsWith(actual));
+    }
+
+    @ParameterizedTest
+    @CsvFileSource(resources = "/o200k_base_encodings.csv", numLinesToSkip = 1, maxCharsPerColumn = 1_000_000)
+    void o200kHarmonyEncodeOrdinaryEncodesCorrectly(
+            String input,
+            String output
+    ) {
+        var expected = TestUtils.parseEncodingString(output);
+        var actual = ENCODING.encodeOrdinary(input);
+
+        assertEquals(expected, actual);
+    }
+
+    @ParameterizedTest
+    @CsvFileSource(resources = "/o200k_base_encodings.csv", numLinesToSkip = 1, maxCharsPerColumn = 1_000_000)
+    void o200kHarmonyEncodeOrdinaryEncodesCorrectly(
+            String input,
+            String output,
+            String outputMaxTokens10
+    ) {
+        var expected = TestUtils.parseEncodingString(output);
+        var expectedWithMaxTokens = TestUtils.parseEncodingString(outputMaxTokens10);
+        var encodingResult = ENCODING.encodeOrdinary(input, 10);
+
+        assertEquals(expectedWithMaxTokens, encodingResult.getTokens());
+        assertEquals(expected.size() > expectedWithMaxTokens.size(), encodingResult.isTruncated());
+    }
+
+    @ParameterizedTest
+    @CsvFileSource(resources = "/o200k_base_encodings.csv", numLinesToSkip = 1, maxCharsPerColumn = 1_000_000)
+    void o200kHarmonyEncodeOrdinaryEncodesStable(String input) {
+        var actual = ENCODING.decode(ENCODING.encodeOrdinary(input));
+
+        assertEquals(input, actual);
+    }
+
+    @ParameterizedTest
+    @CsvFileSource(resources = "/o200k_base_encodings.csv", numLinesToSkip = 1, maxCharsPerColumn = 1_000_000)
+    void o200kHarmonyEncodeOrdinaryEncodesStableWithMaxTokensSet(String input) {
+        var actual = ENCODING.decode(ENCODING.encodeOrdinary(input, 10).getTokens());
+
+        assertTrue(input.startsWith(actual));
+    }
+
+    @Test
+    void o200kHarmonyEncodeOrdinaryEncodesSpecialTokensCorrectly() {
+        var input = "<|startoftext|>Hello<|endoftext|>, <|start|> <|end|> world <|reserved_201088|> ! <|endofprompt|>";
+        var actual = ENCODING.decode(ENCODING.encodeOrdinary(input));
+
+        assertEquals(input, actual);
+    }
+}


### PR DESCRIPTION
Added `o200k_harmony` encoding used by OpenAI's `gpt-oss-120b` and `gpt-oss-20b` models.

Didn't update model mapping as part of this PR as there are other outstanding PRs that should be merged first.

Fixes https://github.com/knuddelsgmbh/jtokkit/issues/131