### PR TITLE
[codex] Add module-info.java via multi-release JAR

### DIFF
--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.util.jar.JarFile
+
 plugins {
     `java-library`
     `maven-publish`
@@ -6,6 +8,9 @@ plugins {
 
 group = "com.knuddels"
 version = "1.2.0-SNAPSHOT"
+
+val moduleName = "com.knuddels.jtokkit"
+val java9 = sourceSets.create("java9")
 
 repositories {
     mavenCentral()
@@ -17,8 +22,24 @@ java {
 }
 
 tasks.withType<JavaCompile> {
-    val javaVersion = if (name == "compileTestJava") 21 else 8
+    val javaVersion = when (name) {
+        java9.compileJavaTaskName, "compileTestJava" -> 21
+        else -> 8
+    }
     javaCompiler = javaToolchains.compilerFor { languageVersion = JavaLanguageVersion.of(javaVersion) }
+}
+
+tasks.named<JavaCompile>(java9.compileJavaTaskName) {
+    classpath = files()
+    destinationDirectory = layout.buildDirectory.dir("classes/java/moduleInfo")
+    options.release = 9
+    options.compilerArgs.addAll(
+        listOf(
+            "--patch-module",
+            "$moduleName=${sourceSets.main.get().output.asPath}"
+        )
+    )
+    dependsOn(tasks.named(sourceSets.main.get().classesTaskName))
 }
 
 dependencies {
@@ -26,9 +47,43 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-params:5.11.1")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.11.1")
 }
+
 tasks.getByName<Test>("test") {
     useJUnitPlatform()
     maxParallelForks = 4
+}
+
+tasks.named<Jar>("jar") {
+    manifest.attributes["Multi-Release"] = "true"
+    into("META-INF/versions/9") {
+        from(tasks.named(java9.compileJavaTaskName)) {
+            include("module-info.class")
+        }
+    }
+}
+
+tasks.named<Jar>("sourcesJar") {
+    from(java9.allSource)
+}
+
+val verifyMultiReleaseJar by tasks.registering {
+    dependsOn(tasks.named("jar"))
+
+    doLast {
+        val jarFile = tasks.named<Jar>("jar").get().archiveFile.get().asFile
+        JarFile(jarFile).use { artifact ->
+            check(artifact.manifest.mainAttributes.getValue("Multi-Release") == "true") {
+                "Expected ${jarFile.name} to be marked as a multi-release JAR."
+            }
+            check(artifact.getEntry("META-INF/versions/9/module-info.class") != null) {
+                "Expected ${jarFile.name} to contain META-INF/versions/9/module-info.class."
+            }
+        }
+    }
+}
+
+tasks.named("check") {
+    dependsOn(verifyMultiReleaseJar)
 }
 
 publishing {

--- a/lib/src/java9/java/module-info.java
+++ b/lib/src/java9/java/module-info.java
@@ -1,0 +1,4 @@
+module com.knuddels.jtokkit {
+    exports com.knuddels.jtokkit;
+    exports com.knuddels.jtokkit.api;
+}


### PR DESCRIPTION
## What changed
Adds a JPMS `module-info.java` for `com.knuddels.jtokkit` while preserving Java 8 compatibility by publishing the library JAR as a multi-release JAR.

## Why
The library targets Java 8, so a plain top-level module descriptor would break that baseline. Packaging `module-info.class` under `META-INF/versions/9/` keeps Java 8 consumers unchanged while exposing a named module on Java 9+.

## Impact
- Java 8 consumers continue to use the library unchanged.
- Java 9+ consumers can require `com.knuddels.jtokkit` as a named module.
- The sources JAR now includes `module-info.java`.

## Validation
- `JAVA_HOME=/opt/sdkman/candidates/java/21.0.8-zulu PATH=/opt/sdkman/candidates/java/21.0.8-zulu/bin:$PATH java -classpath gradle/wrapper/gradle-wrapper.jar org.gradle.wrapper.GradleWrapperMain :lib:check :lib:jar`
- Verified the built JAR contains `META-INF/versions/9/module-info.class`
- Verified the manifest contains `Multi-Release: true`
